### PR TITLE
Enhace developer docs

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -14,7 +14,6 @@
 ## Testing and Building
 
 There are several ways to modify `KVC` and test your changes.
-In all cases we assume users have an active `GitHub` account that is properly setup.
 
 ### Using "docker_make" script
 This method is preferred for developers who have `docker` setup and running on their workstation and don't


### PR DESCRIPTION
This is mainly to get people up and running faster with `kvc` development.
Also adds a section for building and testing `kvc` on the workstation rather than using `docker`.