### PR TITLE
Adding new e2e tests

### DIFF
--- a/test/e2e/kvc_test.go
+++ b/test/e2e/kvc_test.go
@@ -338,7 +338,7 @@ func TestVolumeManager(t *testing.T) {
 			expPVC:     false,
 		},
 		{
-			description: "single vc - S3 - improperly formated timeouti - missing unit",
+			description: "single vc - S3 - improperly formated timeout - missing unit",
 			volumeConfigs: []crv1.VolumeConfig{
 				{
 					ID:          "vol1",


### PR DESCRIPTION
This PR just adds some more test cases for `timeoutForDataDownload` and `Replicas` options.
- Added tests for more replicas than the number of nodes
- Added tests to handle improperly formatted (either negative value, or value with no time unit) for timeoutForDataDownload